### PR TITLE
Fix scheduler concurrency and improve UI filters

### DIFF
--- a/tiny-job-admin-web/src/config.js
+++ b/tiny-job-admin-web/src/config.js
@@ -9,11 +9,11 @@
 // 遵循统一的规范, 好维护, 交给其他人也比较简单
 
 module.exports = {
-  name: 'Ting-Job管理后台',  // 项目的名字
+  name: 'Tiny-Job管理后台',  // 项目的名字
   favicon: 'http://jxy.me/favicon.ico',  // 设置网页的favicon, 可以是外链, 也可以是本地
   footer: '<a>Tiny-job</a>版权所有 © 2015-2099',  // footer中显示的字, 可以嵌入html标签
 
-  debug: true,  // 是否开启debug模式, 不会请求后端接口, 使用mock的数据
+  debug: false,  // 是否开启debug模式, 不会请求后端接口, 使用mock的数据
 
   tabMode: {  // tab模式相关配置
     enable: false,  // 是否开启tab模式
@@ -30,7 +30,7 @@ module.exports = {
   },
 
   api: {  // 对后端请求的相关配置
-    host: 'http://tiny-job.c85eaf0d05d04465a81befded3f4f608b.cn-shenzhen.alicontainer.com',  // 调用ajax接口的地址, 默认值空, 如果是跨域的, 服务端要支持CORS
+    host: '',  // 调用ajax接口的地址, 默认值空, 如果是跨域的, 服务端要支持CORS
     path: '/tiny-job',  // ajax请求的路径
     timeout: 15000,  // 请求的超时时间, 单位毫秒
   },

--- a/tiny-job-admin-web/src/schema/jobinfo.dataSchema.js
+++ b/tiny-job-admin-web/src/schema/jobinfo.dataSchema.js
@@ -30,6 +30,8 @@ module.exports = [
     key: 'jobType',
     title: '任务类型',
     dataType: 'varchar',
+    showType: 'select',
+    options: [{ key: 'http', value: 'HTTP调用' }, { key: 'shell', value: '脚本' }],
   },
   {
     key: 'executeBlockStrategy',
@@ -57,7 +59,7 @@ module.exports = [
     dataType: 'datetime',
     showInForm: false,
     render: (text, record) => {
-      return new Date(text).format('yyyy-MM-dd HH:mm:ss')
+      return text ? new Date(text).format('yyyy-MM-dd HH:mm:ss') : '';
     },
   },
   {
@@ -89,25 +91,22 @@ module.exports = [
     showInForm: false,
   },
   {
-    key: 'jobStatus',
-    title: 'jobStatus',
-    dataType: 'int',
-    showInTable: false,
-    showInForm: false,
-  },
-  {
     key: 'triggerLastTime',
-    title: 'triggerLastTime',
-    dataType: 'int',
-    showInTable: false,
+    title: '上次触发时间',
+    dataType: 'datetime',
     showInForm: false,
+    render: (text) => {
+      return text ? new Date(text).format('yyyy-MM-dd HH:mm:ss') : '';
+    },
   },
   {
     key: 'triggerNextTime',
-    title: 'triggerNextTime',
-    dataType: 'int',
-    showInTable: false,
+    title: '下次触发时间',
+    dataType: 'datetime',
     showInForm: false,
+    render: (text) => {
+      return text ? new Date(text).format('yyyy-MM-dd HH:mm:ss') : '';
+    },
   },
   {
     key: 'jobVersion',

--- a/tiny-job-admin-web/src/schema/jobinfo.querySchema.js
+++ b/tiny-job-admin-web/src/schema/jobinfo.querySchema.js
@@ -20,4 +20,12 @@ module.exports = [
     options: [{ key: '', value: '全部' }, { key: '0', value: '已停止' }, { key: '1', value: '运行中' }],
     defaultValue: '',
   },
+  {
+    key: 'jobType',
+    title: '任务类型',
+    dataType: 'varchar',
+    showType: 'select',
+    options: [{ key: '', value: '全部' }, { key: 'http', value: 'HTTP调用' }, { key: 'shell', value: '脚本' }],
+    defaultValue: '',
+  },
 ];

--- a/tiny-job-admin/src/main/java/com/tiny_job/admin/controller/JobInfoController.java
+++ b/tiny-job-admin/src/main/java/com/tiny_job/admin/controller/JobInfoController.java
@@ -36,12 +36,14 @@ public class JobInfoController {
 
     @RequestMapping("/list")
     @ResponseBody
-    public CommonResult<List<JobInfo>> list(@RequestParam(required = false,defaultValue = "0")int currentPage,
-                                            @RequestParam(required = false,defaultValue = "0")int pageSize,
-                                            Integer jobStatus,String jobDesc) {
+    public CommonResult<List<JobInfo>> list(@RequestParam(required = false,defaultValue = "1")int currentPage,
+                                            @RequestParam(required = false,defaultValue = "20")int pageSize,
+                                            Integer jobStatus,String jobDesc,String jobType) {
         CommonResult<List<JobInfo>> commonResult = new CommonResult<>();
+        currentPage = currentPage <= 0 ? 1 : currentPage;
+        pageSize = pageSize <= 0 ? 20 : pageSize;
         Page page = PageHelper.startPage(currentPage,pageSize);
-        commonResult.setData(jobInfoHelper.jobInfoList(jobStatus,jobDesc));
+        commonResult.setData(jobInfoHelper.jobInfoList(jobStatus,jobDesc,jobType));
         commonResult.setCurrentPage(page.getPageNum());
         commonResult.setPageSize(page.getPageSize());
         commonResult.setTotalRecord(page.getTotal());

--- a/tiny-job-admin/src/main/java/com/tiny_job/admin/thread/JobScheduleHelper.java
+++ b/tiny-job-admin/src/main/java/com/tiny_job/admin/thread/JobScheduleHelper.java
@@ -5,13 +5,16 @@ import com.tiny_job.admin.dao.entity.JobInfo;
 import com.tiny_job.admin.utils.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Resource;
 import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import java.sql.Timestamp;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -49,33 +52,17 @@ public class JobScheduleHelper {
                         break;
                     }
                 }
-                Long nowTime = System.currentTimeMillis();
+                long nowTime = System.currentTimeMillis();
                 try {
-                    List<JobInfo> jobInfos = jobInfoHelper.scheduleJobQuery(nowTime + PRE_READ_TIME * 2, PRE_SIZE);
-                    jobInfos.forEach(jobInfo -> {
+                    List<JobInfo> jobInfos = jobInfoHelper.scheduleJobQuery(nowTime + PRE_READ_TIME * 2L, PRE_SIZE);
+                    for (JobInfo jobInfo : jobInfos) {
                         try {
-                            int resultCount = jobInfoHelper.updateByOptimisticLock(jobInfo);
-                            //影响的记录为0说明已经被其他线程处理，跳过此次job
-                            if (resultCount == 0) {
-                                logger.debug("NO task to scheduler");
-                                return;
-                            }
-                            logger.debug("Try to trigger job", jobInfo);
-
-                            //已经过期的任务，立即调度一次
-                            if (jobInfo.getTriggerNextTime() < nowTime) {
-                                triggerPoolHelper.triggerJob(jobInfo, jobInfo.getTriggerNextTime() - nowTime);
-                                refreshNextValidTime(jobInfo, new Date(nowTime));
-                            }
-                            //判断是否是即将要调度
-                            checkHighFrequency(jobInfo, nowTime);
-                            logTime("final {}", jobInfo.getTriggerNextTime());
-                            jobInfoHelper.updateWithoutOptimisticLock(jobInfo);
+                            scheduleSingleJob(jobInfo, nowTime);
                         }
                         catch (Exception e) {
-                            logger.error("schedule job error,jobInfo{}", jobInfo, e);
+                            logger.error("schedule job error, jobInfo{}", jobInfo, e);
                         }
-                    });
+                    }
                 }
                 catch (Exception e) {
                     logger.error("scheduler job error", e);
@@ -87,38 +74,72 @@ public class JobScheduleHelper {
         scheduleThread.start();
     }
 
-    /**
-     * 如果是超频繁任务，递归生成最近一个周期内的所有触发任务
-     *
-     * @param jobInfo
-     */
-    private void checkHighFrequency(JobInfo jobInfo, Long nowTime) throws ParseException {
-        if (jobInfo.getTriggerNextTime() < (nowTime + PRE_READ_TIME)) {
-            //将任务放入待执行队列
-            triggerPoolHelper.triggerJob(jobInfo, jobInfo.getTriggerNextTime() - nowTime);
-            //更新下次调度job的时间
-            refreshNextValidTime(jobInfo, new Date(jobInfo.getTriggerNextTime()));
-            //判断是否是超高频繁任务，即调度周期小于5s一次
-            checkHighFrequency(jobInfo, nowTime);
+    private void scheduleSingleJob(JobInfo jobInfo, long nowTime) throws ParseException {
+        Long originalNextTimeValue = jobInfo.getTriggerNextTime();
+        if (originalNextTimeValue == null) {
+            logger.warn("skip job {} because triggerNextTime is null", jobInfo.getId());
+            return;
+        }
+        long originalNextTime = originalNextTimeValue;
+        Timestamp originalUpdateTime = jobInfo.getUpdateTime();
+        long lockTriggerTime = nowTime + PRE_READ_TIME * 3L;
+        if (!jobInfoHelper.lockJobForSchedule(jobInfo, lockTriggerTime)) {
+            logger.debug("skip job {} because it is locked by another scheduler", jobInfo.getId());
+            return;
+        }
+        Timestamp lockedUpdateTime = jobInfo.getUpdateTime();
+        jobInfo.setTriggerNextTime(originalNextTime);
+
+        boolean committed = false;
+        try {
+            SchedulePlan schedulePlan = buildSchedulePlan(jobInfo, nowTime);
+            for (TriggerSlot slot : schedulePlan.getTriggerSlots()) {
+                JobInfo snapshot = new JobInfo();
+                BeanUtils.copyProperties(jobInfo, snapshot);
+                snapshot.setTriggerLastTime(slot.getPreviousFireTime());
+                snapshot.setTriggerNextTime(slot.getFireTime());
+                triggerPoolHelper.triggerJob(snapshot, slot.getFireTime() - nowTime);
+            }
+
+            Long nextTriggerTime = schedulePlan.getNextTriggerTime();
+            if (nextTriggerTime == null) {
+                nextTriggerTime = lockTriggerTime;
+                logger.warn("no next trigger time calculated for job {}, fallback to lock window {}", jobInfo.getId(), lockTriggerTime);
+            }
+
+            Long lastTriggerTime = schedulePlan.getLastTriggerTime();
+            committed = jobInfoHelper.finalizeSchedule(jobInfo, lockedUpdateTime, lockTriggerTime, lastTriggerTime, nextTriggerTime);
+            if (!committed) {
+                logger.warn("failed to finalize schedule for job {}", jobInfo.getId());
+            }
+        }
+        finally {
+            if (!committed) {
+                jobInfoHelper.restoreScheduleLock(jobInfo, lockedUpdateTime, lockTriggerTime, originalNextTime, originalUpdateTime);
+            }
         }
     }
 
-
-    private void refreshNextValidTime(JobInfo jobInfo, Date fromTime) throws ParseException {
-        Date nextValidTime = new CronExpression(jobInfo.getJobCron()).getNextValidTimeAfter(fromTime);
-        if (nextValidTime != null) {
-            jobInfo.setTriggerLastTime(jobInfo.getTriggerNextTime());
-            jobInfo.setTriggerNextTime(nextValidTime.getTime());
-            logTime("nnxt", nextValidTime.getTime());
+    private SchedulePlan buildSchedulePlan(JobInfo jobInfo, long nowTime) throws ParseException {
+        CronExpression cronExpression = new CronExpression(jobInfo.getJobCron());
+        long windowLimit = nowTime + PRE_READ_TIME;
+        Long nextTriggerValue = jobInfo.getTriggerNextTime();
+        if (nextTriggerValue == null) {
+            return new SchedulePlan(Collections.emptyList(), jobInfo.getTriggerLastTime(), null);
         }
-        else {
-            logger.warn("nextValidTime is null");
+        long nextTriggerTime = nextTriggerValue;
+        List<TriggerSlot> slots = new ArrayList<>();
+        Long previousFireTime = jobInfo.getTriggerLastTime();
+        while (nextTriggerTime > 0 && nextTriggerTime <= windowLimit) {
+            slots.add(new TriggerSlot(nextTriggerTime, previousFireTime));
+            previousFireTime = nextTriggerTime;
+            Date nextValid = cronExpression.getNextValidTimeAfter(new Date(nextTriggerTime));
+            if (nextValid == null) {
+                return new SchedulePlan(slots, previousFireTime, null);
+            }
+            nextTriggerTime = nextValid.getTime();
         }
-    }
-
-    private void logTime(String msg, Long time) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy年MM月dd日 hh:mm:ss");
-        logger.info("{}:{}", msg, simpleDateFormat.format(time));
+        return new SchedulePlan(slots, previousFireTime, nextTriggerTime);
     }
 
     @PreDestroy
@@ -126,6 +147,48 @@ public class JobScheduleHelper {
         running = false;
         if (scheduleThread != null) {
             scheduleThread.interrupt();
+        }
+    }
+
+    private static final class TriggerSlot {
+        private final long fireTime;
+        private final Long previousFireTime;
+
+        private TriggerSlot(long fireTime, Long previousFireTime) {
+            this.fireTime = fireTime;
+            this.previousFireTime = previousFireTime;
+        }
+
+        public long getFireTime() {
+            return fireTime;
+        }
+
+        public Long getPreviousFireTime() {
+            return previousFireTime;
+        }
+    }
+
+    private static final class SchedulePlan {
+        private final List<TriggerSlot> triggerSlots;
+        private final Long lastTriggerTime;
+        private final Long nextTriggerTime;
+
+        private SchedulePlan(List<TriggerSlot> triggerSlots, Long lastTriggerTime, Long nextTriggerTime) {
+            this.triggerSlots = Collections.unmodifiableList(triggerSlots);
+            this.lastTriggerTime = lastTriggerTime;
+            this.nextTriggerTime = nextTriggerTime;
+        }
+
+        public List<TriggerSlot> getTriggerSlots() {
+            return triggerSlots;
+        }
+
+        public Long getLastTriggerTime() {
+            return lastTriggerTime;
+        }
+
+        public Long getNextTriggerTime() {
+            return nextTriggerTime;
         }
     }
 }

--- a/tiny-job-admin/src/main/java/com/tiny_job/admin/thread/JobTriggerPoolHelper.java
+++ b/tiny-job-admin/src/main/java/com/tiny_job/admin/thread/JobTriggerPoolHelper.java
@@ -32,8 +32,15 @@ public class JobTriggerPoolHelper {
     @Resource
     private JobInfoHelper jobInfoHelper;
 
-    @Autowired
-    private Map<String, TinyJobExecutorBaseAdapter> tinyJobExecutor = new ConcurrentHashMap<>();
+    private final Map<String, TinyJobExecutorBaseAdapter> tinyJobExecutor = new ConcurrentHashMap<>();
+
+    @Autowired(required = false)
+    public void setTinyJobExecutor(Map<String, TinyJobExecutorBaseAdapter> executors) {
+        tinyJobExecutor.clear();
+        if (executors != null) {
+            tinyJobExecutor.putAll(executors);
+        }
+    }
 
     private ScheduledThreadPoolExecutor triggerPool;
 


### PR DESCRIPTION
## Summary
- ensure the job scheduler uses a timestamp-based optimistic lock to avoid duplicate triggers
- harden the scheduling threads with graceful shutdown behaviour for the trigger pool and scheduler loop
- expose job status/type filters and runtime columns on the web console while wiring the UI to the live API

## Testing
- `mvn -pl tiny-job-admin -am -DskipTests package` *(fails: unable to download parent POM from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e3329ee48333914fcbe893ede988